### PR TITLE
Added image resizing

### DIFF
--- a/SignatureToImage.cs
+++ b/SignatureToImage.cs
@@ -56,8 +56,13 @@ namespace ConsumedByCode.SignatureToImage
 	    {
 	        return SigJsonToImage(json, new Size(CanvasWidth, CanvasHeight));
 	    }
-	        
-	        
+
+        /// <summary>
+        /// Draws a signature based on the JSON provided by Signature Pad.
+        /// </summary>
+        /// <param name="json">JSON string of line drawing commands.</param>
+        /// <param name="size">System.Drawing.Size structure containing Width and Height dimensions.</param>
+        /// <returns>Bitmap image containing the signature.</returns>
         public Bitmap SigJsonToImage(string json, Size size)
         {
             var signatureImage = GetBlankCanvas();
@@ -87,6 +92,18 @@ namespace ConsumedByCode.SignatureToImage
         /// <param name="fontPath">Full path of font file to be used if default font is not installed on the system.</param>
         /// <returns>Bitmap image containing the user's signature.</returns>
         public Bitmap SigNameToImage(string name, string fontPath = null)
+        {
+            return SigNameToImage(name, null, fontPath);
+        }
+
+        /// <summary>
+        /// Draws an approximation of a signature using a font.
+        /// </summary>
+        /// <param name="name">The string that will be drawn.</param>
+        /// <param name="size">System.Drawing.Size structure containing Width and Height dimensions.</param>
+        /// <param name="fontPath">Full path of font file to be used if default font is not installed on the system.</param>
+        /// <returns>Bitmap image containing the user's signature.</returns>
+        public Bitmap SigNameToImage(string name, Size size, string fontPath = null)
         {
             var signatureImage = GetBlankCanvas();
             if (!string.IsNullOrWhiteSpace(name))
@@ -132,7 +149,7 @@ namespace ConsumedByCode.SignatureToImage
                     signatureGraphic.DrawString(name, font, new SolidBrush(PenColor), 0, 0);
                 }
             }
-            return signatureImage;
+            return (Bitmap)((size.Width == CanvasWidth && size.Height == CanvasHeight) ? signatureImage : ResizeImage(signatureImage, size));
         }
 
         /// <summary>
@@ -151,8 +168,10 @@ namespace ConsumedByCode.SignatureToImage
         }
         
         /// <summary>
-	/// Resizes the image to fit the canvas in the event that the signature was drawn larger than it will be redisplayed.
-	/// </summary>
+        /// Resizes the image to fit the canvas in the event that the signature was drawn larger than it will be redisplayed.
+        /// </summary>
+        /// <param name="img">The image that will be resized.</param>
+        /// <param name="size">System.Drawing.Size structure containing the new Width and Height dimensions.</param>
         /// <returns>Resized image.</returns>
         private Image ResizeImage(Image img, Size size)
 	    {

--- a/SignatureToImage.cs
+++ b/SignatureToImage.cs
@@ -53,6 +53,12 @@ namespace ConsumedByCode.SignatureToImage
         /// <param name="json">JSON string of line drawing commands.</param>
         /// <returns>Bitmap image containing the signature.</returns>
         public Bitmap SigJsonToImage(string json)
+	{
+	    return SigJsonToImage(json, new Size(CanvasWidth, CanvasHeight));
+	}
+	        
+	        
+        public Bitmap SigJsonToImage(string json, Size size)
         {
             var signatureImage = GetBlankCanvas();
             if (!string.IsNullOrWhiteSpace(json))
@@ -71,7 +77,7 @@ namespace ConsumedByCode.SignatureToImage
                     }
                 }
             }
-            return signatureImage;
+            return (Bitmap)((size.Width == CanvasWidth && size.Height == CanvasHeight) ? signatureImage : ResizeImage(signatureImage, size));
         }
 
         /// <summary>
@@ -142,6 +148,36 @@ namespace ConsumedByCode.SignatureToImage
                 signatureGraphic.Clear(BackgroundColor);
             }
             return blankImage;
+        }
+        
+        /// <summary>
+	/// Resizes the image to fit the canvas in the event that the signature was drawn larger than it will be redisplayed.
+	/// </summary>
+        /// <returns>Resized image.</returns>
+        private Image ResizeImage(Image img, Size size)
+	{
+	    int srcWidth = img.Width;
+	    int srcHeight = img.Height;
+
+	    float percent = 0;
+	    float percWidth = 0;
+	    float percHeight = 0;
+
+	    percWidth = ((float)size.Width / (float)srcWidth);
+	    percHeight = ((float)size.Height / (float)srcHeight);
+	    percent = (percHeight < percWidth) ? percHeight : percWidth;
+
+	    int destWidth = (int)(srcWidth * percent);
+	    int destHeight = (int)(srcHeight * percent);
+
+	    Bitmap bmp = new Bitmap(destWidth, destHeight);
+
+	    Graphics graphic = Graphics.FromImage((Image)bmp);
+	    graphic.InterpolationMode = InterpolationMode.HighQualityBicubic;
+	    graphic.DrawImage(img, 0, 0, destWidth, destHeight);
+	    graphic.Dispose();
+
+	    return (Image)bmp;
         }
 
         /// <summary>

--- a/SignatureToImage.cs
+++ b/SignatureToImage.cs
@@ -53,9 +53,9 @@ namespace ConsumedByCode.SignatureToImage
         /// <param name="json">JSON string of line drawing commands.</param>
         /// <returns>Bitmap image containing the signature.</returns>
         public Bitmap SigJsonToImage(string json)
-	{
-	    return SigJsonToImage(json, new Size(CanvasWidth, CanvasHeight));
-	}
+	    {
+	        return SigJsonToImage(json, new Size(CanvasWidth, CanvasHeight));
+	    }
 	        
 	        
         public Bitmap SigJsonToImage(string json, Size size)
@@ -155,29 +155,29 @@ namespace ConsumedByCode.SignatureToImage
 	/// </summary>
         /// <returns>Resized image.</returns>
         private Image ResizeImage(Image img, Size size)
-	{
-	    int srcWidth = img.Width;
-	    int srcHeight = img.Height;
+	    {
+	        int srcWidth = img.Width;
+	        int srcHeight = img.Height;
 
-	    float percent = 0;
-	    float percWidth = 0;
-	    float percHeight = 0;
+	        float percent = 0;
+	        float percWidth = 0;
+	        float percHeight = 0;
 
-	    percWidth = ((float)size.Width / (float)srcWidth);
-	    percHeight = ((float)size.Height / (float)srcHeight);
-	    percent = (percHeight < percWidth) ? percHeight : percWidth;
+	        percWidth = ((float)size.Width / (float)srcWidth);
+	        percHeight = ((float)size.Height / (float)srcHeight);
+	        percent = (percHeight < percWidth) ? percHeight : percWidth;
 
-	    int destWidth = (int)(srcWidth * percent);
-	    int destHeight = (int)(srcHeight * percent);
+	        int destWidth = (int)(srcWidth * percent);
+	        int destHeight = (int)(srcHeight * percent);
 
-	    Bitmap bmp = new Bitmap(destWidth, destHeight);
+	        Bitmap bmp = new Bitmap(destWidth, destHeight);
 
-	    Graphics graphic = Graphics.FromImage((Image)bmp);
-	    graphic.InterpolationMode = InterpolationMode.HighQualityBicubic;
-	    graphic.DrawImage(img, 0, 0, destWidth, destHeight);
-	    graphic.Dispose();
+	        Graphics graphic = Graphics.FromImage((Image)bmp);
+	        graphic.InterpolationMode = InterpolationMode.HighQualityBicubic;
+	        graphic.DrawImage(img, 0, 0, destWidth, destHeight);
+	        graphic.Dispose();
 
-	    return (Image)bmp;
+	        return (Image)bmp;
         }
 
         /// <summary>


### PR DESCRIPTION
Some use cases require a larger signature capture, but a smaller display. These changes allow for passing in a size to resize the image to fit the smaller canvas.

For example, the project I used this in required a 800 x 600 signature capture for touch screens, but displaying that signature as an image in a PDF made it too large, while reducing the canvas size of the SignatureToImage object didn't resize the image, but merely cut it off. This fixes that.
